### PR TITLE
Add config to build wheels using Graviton2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,10 @@ jobs:
   include:
     - stage: Build and test wheel
       os: linux
-      arch: arm64
+      arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=aarch64
@@ -107,7 +110,10 @@ jobs:
         - MB_PYTHON_OSX_VER=10.9
 
     - stage: Test wheel
-      arch: arm64
+      arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=aarch64


### PR DESCRIPTION
This adds the extra config needed to build on Graviton2 instances.